### PR TITLE
Cleanup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN mkdir -p /opt/app-root/src/.config/composer && \
     fi
 
 # Install required packages
-
 RUN dnf install -y mysql jq && \
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf install -y msmtp && \


### PR DESCRIPTION
- Remove unused `AZURE_SQL_SSL_CA_PATH`
- Stop downloading unused `DigiCertGlobalRootCA.crt.pem`
- Instal native `mysql` package